### PR TITLE
Transparent category colors and some related UI polish for the categorization page

### DIFF
--- a/components/coloring-listgroup.vue
+++ b/components/coloring-listgroup.vue
@@ -50,58 +50,6 @@
 
 		methods: {
 
-			colorListGroupItem_Transparency(p_event) {
-
-				// 1. Get the list group item element
-				let clickedListGroupItem = document.getElementById(p_event.target.id);
-				let itemIndex = parseInt(p_event.target.id.split("_")[1])
-				let itemText = clickedListGroupItem.innerText;
-
-				// 2. Determine if clicked list group item will be transparent or opaque
-				let currentOpacity = clickedListGroupItem.style.opacity;
-				let makingOpaque = ( this.defaultOpacity == currentOpacity || 
-									 "" == currentOpacity );
-
-				// NOTE: Blank style string means it is fully opaque.
-				// This occurs because Vue CSS is considered to be an external stylesheet
-				// If needs for more dynamic CSS styling arises, may need to re-address
-
-				// 3. Make all list group items transparent
-				let listGroup = document.getElementById(this.tag + "-listgroup");
-				for ( let index = 0; index < listGroup.children.length; index++ ) {
-					
-					// A. Make the list group item transparent
-					listGroup.children[index].style.opacity = this.defaultOpacity;
-				}
-
-				// 4. Change the opacity of the clicked list group item
-
-				// A. Make the clicked list group item opaque
-				if ( makingOpaque ) {
-
-					// I. Make the item opaque
-					clickedListGroupItem.style.opacity = this.clickedOpacity;
-
-					// II. Tell the parent page column painting has begun
-					this.$emit("opacity-action", {
-						category: itemText,
-						opacity: clickedListGroupItem.style.opacity
-					});
-				}
-				// B. Else, make the clicked list group item transparent
-				else {
-
-					// I. Make the item transparent
-					clickedListGroupItem.style.opacity = this.defaultOpacity;
-
-					// II. Tell the parent page column painting has ended
-					this.$emit("opacity-action", {
-						category: "",
-						opacity: clickedListGroupItem.style.opacity
-					});
-				}
-			},
-
 			colorListGroupItem(p_event) {
 
 				// 1. Get the list group item element

--- a/components/coloring-listgroup.vue
+++ b/components/coloring-listgroup.vue
@@ -15,6 +15,7 @@
 				<b-list-group-item 
 					v-for="(column, index) in columnData.names"
 					v-on:click="colorListGroupItem"
+					:class="'column-paint-' + index"
 					:id="tag + '_' + index"
 					:key="index">
 					{{ column }}
@@ -38,7 +39,68 @@
 			"b-list-group-item": BListGroupItem
 		},
 
+		data() {
+
+			return {
+
+				clickedOpacity: "1.0",
+				defaultOpacity: "0.5"
+			}
+		},
+
 		methods: {
+
+			colorListGroupItem_Transparency(p_event) {
+
+				// 1. Get the list group item element
+				let clickedListGroupItem = document.getElementById(p_event.target.id);
+				let itemIndex = parseInt(p_event.target.id.split("_")[1])
+				let itemText = clickedListGroupItem.innerText;
+
+				// 2. Determine if clicked list group item will be transparent or opaque
+				let currentOpacity = clickedListGroupItem.style.opacity;
+				let makingOpaque = ( this.defaultOpacity == currentOpacity || 
+									 "" == currentOpacity );
+
+				// NOTE: Blank style string means it is fully opaque.
+				// This occurs because Vue CSS is considered to be an external stylesheet
+				// If needs for more dynamic CSS styling arises, may need to re-address
+
+				// 3. Make all list group items transparent
+				let listGroup = document.getElementById(this.tag + "-listgroup");
+				for ( let index = 0; index < listGroup.children.length; index++ ) {
+					
+					// A. Make the list group item transparent
+					listGroup.children[index].style.opacity = this.defaultOpacity;
+				}
+
+				// 4. Change the opacity of the clicked list group item
+
+				// A. Make the clicked list group item opaque
+				if ( makingOpaque ) {
+
+					// I. Make the item opaque
+					clickedListGroupItem.style.opacity = this.clickedOpacity;
+
+					// II. Tell the parent page column painting has begun
+					this.$emit("opacity-action", {
+						category: itemText,
+						opacity: clickedListGroupItem.style.opacity
+					});
+				}
+				// B. Else, make the clicked list group item transparent
+				else {
+
+					// I. Make the item transparent
+					clickedListGroupItem.style.opacity = this.defaultOpacity;
+
+					// II. Tell the parent page column painting has ended
+					this.$emit("opacity-action", {
+						category: "",
+						opacity: clickedListGroupItem.style.opacity
+					});
+				}
+			},
 
 			colorListGroupItem(p_event) {
 
@@ -61,8 +123,11 @@
 				for ( let index = 0; index < listGroup.children.length; index++ ) {
 					
 					// A. Decolor the list group item
-					listGroup.children[index].style.backgroundColor = this.defaultPalette.bColor;
-					listGroup.children[index].style.color = this.defaultPalette.fColor;
+					// listGroup.children[index].style.backgroundColor = this.defaultPalette.bColor;
+					// listGroup.children[index].style.color = this.defaultPalette.fColor;
+
+					// B. Make the list group item transparent
+					listGroup.children[index].style.opacity = this.defaultOpacity;
 				}
 
 				// 4. Change the background and foreground colors of the clicked list group item
@@ -71,10 +136,13 @@
 				if ( coloringItem ) {
 
 					// I. Color the item
-					clickedListGroupItem.style.backgroundColor = this.columnData.backgroundColors[itemIndex];
-					clickedListGroupItem.style.color = this.columnData.foregroundColors[itemIndex];
+					// clickedListGroupItem.style.backgroundColor = this.columnData.backgroundColors[itemIndex];
+					// clickedListGroupItem.style.color = this.columnData.foregroundColors[itemIndex];
 
-					// II. Tell the parent page column painting has begun
+					// II. Make the item opaque
+					clickedListGroupItem.style.opacity = this.clickedOpacity;
+
+					// III. Tell the parent page column painting has begun
 					this.$emit("paint-action", {
 						category: itemText,
 						bColor:this.columnData.backgroundColors[itemIndex],
@@ -88,7 +156,10 @@
 					clickedListGroupItem.style.backgroundColor = this.defaultPalette.bColor;
 					clickedListGroupItem.style.color = this.defaultPalette.fColor;
 
-					// II. Tell the parent page column painting has ended
+					// II. Make the item transparent
+					clickedListGroupItem.style.opacity = this.defaultOpacity;
+
+					// III. Tell the parent page column painting has ended
 					this.$emit("paint-action", {
 						category:"",
 						bColor:this.defaultPalette.bColor,
@@ -104,6 +175,37 @@
 </script>
 
 <style>
+
+.column-paint-0 {
+
+	background-color: rgb(164,208,90);
+	color: black;
+	opacity: 1.0;
+}
+.column-paint-1 {
+	
+	background-color: rgb(127,23,167);
+	color: white;
+	opacity: 0.5;
+}
+.column-paint-2 {
+	
+	background-color: rgb(70,76,174);
+	color: white;	
+	opacity: 0.5;	
+}
+.column-paint-3 {
+	
+	background-color: rgb(236,197,50);
+	color: black;
+	opacity: 0.5;	
+}
+.column-paint-4 {
+	
+	background-color: rgb(128,1,1);
+	color: white;
+	opacity: 0.5;	
+}
 
 .instructions-text {
 

--- a/components/filedata-table.vue
+++ b/components/filedata-table.vue
@@ -1,9 +1,10 @@
 <template>
 
-	<div>
+	<div class="card">
 		<b-table
 			bordered hover
 			:fields="fields"
+			head-variant="dark"
 			id="column-paint-table"
 			:items="tableData"
 			primary-key="primary-key"
@@ -12,7 +13,6 @@
 			:tbody-tr-class="paintClass">
 		</b-table>
 
-		<table></table>
 	</div>
 
 </template>

--- a/pages/categorization.vue
+++ b/pages/categorization.vue
@@ -11,8 +11,8 @@
 					:columnData="recommendedColumns"
 					:defaultPalette="$store.state.pageData.categorization.default"
 					tag="recommended-column"
-					title="Recommended Columns"
-					instructions="Click column type and then corresponding column from tsv file"
+					title="Recommended Categories"
+					instructions="Click category and then corresponding column from tsv file"
 					v-on:paint-action="$store.dispatch('saveCurrentPaintInfo', $event)"
 					>
 				</coloring-listgroup>
@@ -64,6 +64,9 @@
 
 			// Determine page state from data contents and change to that new state
 			this.changeToNewState();
+
+			// Set the default painting color to the colors of the first painting class
+			this.setCurrentPaintClass(0);
 		},		
 
 		data() {
@@ -75,6 +78,7 @@
 
 					{ key: "column" },
 					{ key: "description" }
+					// thStyle: "filedata-table-header
 				],
 
 				// Current state of the page
@@ -170,14 +174,8 @@
 				if ( null == tsvFile && null == jsonFile )
 					return [];
 
-				console.log("Point 1");
-				console.log("tsvFile: " + tsvFile);
-				console.log("jsonFile: " + jsonFile);
-
 				// Uses both tsv and json data
 				if ( null != jsonFile ) {
-
-					console.log("Point 2a");
 
 					// 1. Produce an array of dicts
 					var tsvJsonDictArray = [];
@@ -201,12 +199,8 @@
 							"column": headerField,
 							"description": "",
 							"primary-key": tsvJsonIndex - 1
-							//"bColor": this.$store.state.columnCategorization.default.bColor,
-							//"fColor": this.$store.state.columnCategorization.default.fColor,
 						});
 					}
-
-					console.log("Point 2b");
 
 					// B. and a corresponding "description" column that is (possibly) sourced from the json file
 					for ( let json_column in jsonFile ) {
@@ -239,15 +233,11 @@
 						}
 					}
 
-					console.log("Point 2c");
-
 					// 2. Save the table in this component's data
 					this.$store.dispatch("saveTableData", tsvJsonDictArray);
 				}
 				// Uses just tsv data
 				else {
-
-					console.log("Point 3a");
 
 					// 1. Produce an array of dicts
 					var tsvDictArray = [];
@@ -266,8 +256,6 @@
 						});
 					}
 
-					console.log("Point 3b");
-
 					// 2. Save the table in this component's data
 					this.$store.dispatch("saveTableData", tsvDictArray);
 				}
@@ -279,16 +267,12 @@
 		methods: {
 
 			annotationPageAccess(p_enable) {
-
-				console.log("Annotation page access with p_enable: " + p_enable);
 				
 				// 1. Enable/disable access to the annotation page on the nav bar
 				for ( let index = 0; index < this.navItemsState.length; index++ ) {
 					
 					// A. Look for the annotation nav item
 					if ( this.pageNames.annotation.pageName == this.navItemsState[index].pageInfo.pageName ) {
-
-						console.log("Found annotation pagename");
 						
 						// i. Enable/disable the annotation nav item
 						this.navItemsState[index].enabled = p_enable;
@@ -378,8 +362,6 @@
 					}
 				}
 
-				console.log("Column count: " + columnCount);
-
 				return columnCount;
 			},
 
@@ -406,27 +388,21 @@
 				switch ( tableRowBColor ) {
 
 					case this.recommendedColumns.backgroundColors[0]:
-						console.log("Class zero");
 						paintClass = this.paintClasses.paint0;
 						break;
 					case this.recommendedColumns.backgroundColors[1]:
-						console.log("Class one");
 						paintClass = this.paintClasses.paint1;
 						break;
 					case this.recommendedColumns.backgroundColors[2]:
-						console.log("Class two");
 						paintClass = this.paintClasses.paint2;
 						break;
 					case this.recommendedColumns.backgroundColors[3]:
-						console.log("Class four");
 						paintClass = this.paintClasses.paint3;
 						break;
 					case this.recommendedColumns.backgroundColors[4]:
-						console.log("Class five");
 						paintClass = this.paintClasses.paint4;
 						break;
 					default:
-						console.log("Class default");
 						paintClass = this.paintClasses.paintDefault;
 						break;
 				}
@@ -447,7 +423,18 @@
 				// ID example: column-paint-table__row_0
 
 				return "column-paint-table" + "__row_" + p_primaryKey;
-			},						
+			},
+
+			setCurrentPaintClass(p_index) {
+
+				// Set background color, foreground color, and category from the built in values
+				this.$store.dispatch("saveCurrentPaintInfo", {
+
+					bColor: this.recommendedColumns.backgroundColors[p_index],
+					category: this.recommendedColumns.names[p_index],
+					fColor: this.recommendedColumns.foregroundColors[p_index]
+				});
+			},					
 
 			tableClick(p_clickData) {
 
@@ -484,7 +471,7 @@
 </script>
 
 <!-- Page styles -->
-<style scoped>
+<style>
 
 	.column-paint-default {
 
@@ -494,28 +481,34 @@
 
 	.column-paint-0 {
 
-		background-color: "rgb(164,208,90)";
-		color: "black";
+		background-color: rgb(164,208,90);
+		color: black;
 	}
 	.column-paint-1 {
 		
-		background-color: "rgb(127,23,167)";
-		color: "white";
+		background-color: rgb(127,23,167);
+		color: white;
 	}
 	.column-paint-2 {
 		
-		background-color: "rgb(70,76,174)";
-		color: "white";		
+		background-color: rgb(70,76,174);
+		color: white;		
 	}
 	.column-paint-3 {
 		
-		background-color: "rgb(236,197,50)";
-		color: "black";		
+		background-color: rgb(236,197,50);
+		color: black;		
 	}
 	.column-paint-4 {
 		
-		background-color: "rgb(128,1,1)";
-		color: "white";		
+		background-color: rgb(128,1,1);
+		color: white;		
+	}
+
+	.filedata-table-header {
+
+		background-color: black;
+		color: white;
 	}
 				
 </style>

--- a/store/index.js
+++ b/store/index.js
@@ -164,10 +164,6 @@ export const mutations = {
 
 	addColumnCategorization(p_state, p_categorization) {
 
-		console.log("addColumnCategorization p_categorization: " + JSON.stringify(p_categorization));
-		console.log("paintingData keys: " + Object.keys(p_state.pageData.categorization.paintingData));
-		console.log("dataDictionaryColumn: " + p_categorization.dataDictionaryColumn);
-
 		// Save the categorization in the store using the column name as a key
 		p_state.pageData.categorization.paintingData[p_categorization.dataDictionaryColumn] = {
 			tsvCategory: p_categorization.tsvCategory,


### PR DESCRIPTION
1. The categories on the categorization page's category listbox are now always colored to indicate to the user which category corresponds with which color.
2. The currently selected category (for 'painting' the participants.tsv/data dictionary json table opposite the category listbox) is now fully opaque while the other categories are made to be half-transparent.
3. When created, the categorization page starts out as painting the first possible category (currently 'Subject ID').
4. Some change to the header and descriptive instruction text to reflect our terminology change to 'category'.