### PR TITLE
Page state preservation for Categorization page, Palette/Table clicking simplification, and general cleanup for landing and categorization pages

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -31,3 +31,17 @@
 	color: white;
 	opacity: 0.5;	
 }
+
+/* Bootstrap styles */
+
+.container-fluid {
+		
+	padding: 0;
+}
+
+.row {
+
+	margin: 1em;
+	padding-left: 2em;
+	padding-right: 2em;
+}

--- a/components/coloring-listgroup.vue
+++ b/components/coloring-listgroup.vue
@@ -13,12 +13,12 @@
 		<b-row>
 			<b-list-group :id="tag + '-listgroup'">
 				<b-list-group-item 
-					v-for="(column, index) in categoryData.names"
-					v-on:click="colorListGroupItem"
+					v-for="(category, index) in categories"
+					v-on:click="changeListGroupItemOpacity"
 					:class="['category-style-' + index, 'coloring-listgroup-item']"
 					:id="tag + '_' + index"
 					:key="index">
-					{{ column }}
+					{{ category }}
 				</b-list-group-item>
 			</b-list-group>
 		</b-row>
@@ -50,17 +50,12 @@
 
 		methods: {
 
-			colorListGroupItem(p_event) {
+			changeListGroupItemOpacity(p_event) {
 
 				// 1. Get the list group item element
 				let clickedListGroupItem = document.getElementById(p_event.target.id);
 				let itemIndex = parseInt(p_event.target.id.split("_")[1])
 				let itemText = clickedListGroupItem.innerText;
-
-				let styleObject = window.getComputedStyle(clickedListGroupItem);
-				console.log("Computed background color for clicked list group item: " + styleObject.getPropertyValue('background-color'));
-				console.log("Computed color for clicked list group item: " + styleObject.getPropertyValue('color'));
-				
 
 				// 2. Determine if clicked list group item will be opaque or transparent
 				let currentOpacity = clickedListGroupItem.style.opacity;
@@ -91,8 +86,8 @@
 					this.$emit("paint-action", {
 
 						category: itemText,
-						bColor:this.categoryData.backgroundColors[itemIndex],
-						fColor:this.categoryData.foregroundColors[itemIndex]
+						bColor:this.$store.getters.palette.backgroundColors[itemIndex],
+						fColor:this.$store.getters.palette.foregroundColors[itemIndex]
 					});
 				} 
 				// B. Else, make the clicked list group item transparent
@@ -112,12 +107,12 @@
 			}
 		},
 
-		props: ["categoryData", "defaultPalette", "instructions", "title", "tag"]
+		props: ["categories", "defaultPalette", "instructions", "title", "tag"]
 	}
 
 </script>
 
-<style>
+<style scoped>
 
 .instructions-text {
 

--- a/components/filedata-table.vue
+++ b/components/filedata-table.vue
@@ -1,6 +1,6 @@
 <template>
 
-	<div class="card">
+	<div id="filedata-table" class="card">
 		<b-table
 			bordered hover
 			:fields="fields"
@@ -9,8 +9,7 @@
 			:items="tableData"
 			primary-key="primary-key"
 			@row-clicked="tableRowClick"
-			select-mode="multi"
-			:tbody-tr-class="paintClass">
+			select-mode="multi">
 		</b-table>
 
 	</div>
@@ -44,7 +43,7 @@
 			}
 		},
 
-		props: ["currentPalette", "defaultPalette", "fields", "paintClass", "tableData", "tableID"]
+		props: ["currentPalette", "defaultPalette", "fields", "tableData", "tableID"]
 	}
 
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,7 @@
 			<h2>TSV File</h2>
 
 			<!-- Debug component - shows file contents -->			
-			<textarea rows="5" cols="200" v-model="stringifiedTsvFile" :key="currentState"></textarea>
+			<textarea rows="5" cols="200" v-model="stringifiedTsvFile"></textarea>
 			
 			<!-- Selects participant.tsv file -->
 			<file-selector 
@@ -24,7 +24,7 @@
 			<h2>Data dictionary</h2>
 
 			<!-- Debug component - shows file contents -->			
-			<textarea rows="5" cols="200" v-model="stringifiedJsonFile" :key="currentState"></textarea>
+			<textarea rows="5" cols="200" v-model="stringifiedJsonFile"></textarea>
 
 			<!-- Selects participant.json file -->
 			<file-selector 
@@ -59,19 +59,20 @@
 	export default {
 		
 		name: "IndexPage",
+		
+		mounted() {
 
-		created() {
+			// 1. Check to see if the palette has been retrieved from the stylesheet
+			if ( !this.$store.getters.hasPalette )
+				this.$store.dispatch("retrievePalette");
 
-			// Determine page state from data contents and change to that new state
+			// 2. Determine page state from data contents and change to that new state
 			this.changeToNewState();
 		},
 
 		data() {
 
 			return {
-
-				// Current state of the page
-				currentState: 0,
 
 				// Full text name of this page
 				fullName: this.$store.getters.pageNames.home.fullName, 
@@ -276,19 +277,3 @@
 		}
 	}
 </script>
-
-<!-- App styles -->
-<style>
-
-	.container-fluid {
-		
-		padding: 0;
-	}
-
-	.row {
-	
-		margin: 1em;
-		padding-left: 2em;
-		padding-right: 2em;
-	}
-</style>


### PR DESCRIPTION
1. Fix for preserving page state of categorization page - table is (re)painted on page load based on info in the store (see 3 below)
2. Retrieval of palette on page load (see `mounted()` in each page) from stylesheet and placement of palette in store for later use by JS components
    - Current colors for table painting are immediately set afterward (`setCurrentPaintClass(0)` in `categorization.vue`) and placed in the store
3. Replacement of old way(s) of table painting with simplified method
    - Table row is styled appropriately upon click
    - Row ID is placed in store upon table row click and easily identified and repainted (see `paintTable()` in `categorization.vue`)
4. Removal of old and now-unused functions and data
5. General streamlining of landing and categorization pages/components