### PR TITLE
Creating a layout for the tool and moving navbar to the layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,0 +1,38 @@
+<template>
+  
+    <div>
+
+        <!-- Navigation bar -->
+        <tool-navbar 
+            :nav-items="pageData"
+            :nav-order="pageOrder"
+            :page-name="pageData[currentPage].fullName">
+        </tool-navbar>
+        
+        <!-- Current page -->
+        <Nuxt />
+  
+    </div>
+
+</template>
+
+<script>
+
+    // Allows for reference to store data by creating simple, implicit getters
+    // Fields listed in mapState below can be found in the store (index.js)
+    import { mapState } from "vuex";
+
+    export default {
+
+        computed: {
+                
+            ...mapState([
+
+                "currentPage",
+                "pageData",
+                "pageOrder"
+            ])
+        }
+    }
+
+</script>

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -1,12 +1,6 @@
 <template>
   <b-container fluid>
-    <!-- Navigation bar -->
-    <tool-navbar
-      :navItems="pageData"
-      :navOrder="pageOrder"
-      :pageName="pageData.annotation.fullName"
-    >
-    </tool-navbar>
+
     <!--
         TODO: revisit the client-side render solution or remove this comment
         The v-for statement below was causing a mismatch between client-side and server-side
@@ -65,8 +59,7 @@ export default {
     ...mapState([
       "columnToCategoryMap",
       "dataTable",
-      "pageData",
-      "pageOrder"
+      "pageData"
     ]),
   },
   methods: {
@@ -93,6 +86,13 @@ export default {
       this.$store.dispatch("saveAnnotatedDataTable", event.transformedTable);
     },
   },
+
+    mounted() {
+
+        // 1. Set the current page name
+        this.$store.dispatch("setCurrentPage", "annotation");
+    }
+
 };
 </script>
 

--- a/pages/categorization.vue
+++ b/pages/categorization.vue
@@ -2,13 +2,6 @@
 
 	<b-container fluid>
 
-		<!-- Navigation bar -->
-		<tool-navbar 
-			:navItems="pageData"
-			:navOrder="pageOrder"
-			:pageName="pageData.categorization.fullName">
-		</tool-navbar>
-
 		<b-row>
 
 			<!-- Category selection table -->
@@ -70,7 +63,10 @@ export default {
 
 		mounted() {
 
-			// 1. Create the data structure for the category to column linking table
+            // 1. Set the current page name
+            this.$store.dispatch("setCurrentPage", "categorization");
+
+			// 2. Create the data structure for the category to column linking table
 			this.setupColumnToCategoryTable();
 
 			// 2. Set selected category to the first category by default
@@ -126,8 +122,7 @@ export default {
 				"columnToCategoryMap",
 				"dataTable",
 				"dataDictionary",
-				"pageData",
-				"pageOrder"
+				"pageData"
     		])
   		},
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -165,8 +165,6 @@
 
         mounted() {
 
-            console.log("Index mounted");
-
             // 1. Set the current page
             this.$store.dispatch("setCurrentPage", "home");
         },		

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,13 +2,6 @@
 
 	<b-container fluid>
 
-		<!-- Navigation bar -->
-		<tool-navbar
-			:navItems="pageData"
-			:navOrder="pageOrder"
-			:pageName="pageData.home.fullName">
-		</tool-navbar>
-
 		<!-- Data table file loading area -->
 		<b-row>
 			<h2>Data table</h2>
@@ -94,8 +87,7 @@
 
 				"dataDictionary",
 				"dataTable",
-				"pageData",
-				"pageOrder"
+				"pageData"
 			]),
 
 			stringifiedDataDictionary() {
@@ -169,6 +161,14 @@
 				// 1. Update the store with json file data
 				this.$store.dispatch("saveDataDictionary", newFileData);
 			},
-		}
+		},
+
+        mounted() {
+
+            console.log("Index mounted");
+
+            // 1. Set the current page
+            this.$store.dispatch("setCurrentPage", "home");
+        },		
 	}
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -3,6 +3,8 @@ export const state = () => ({
 
 	// Page-related data
 
+	currentPage: "home",
+
 	pageData: {
 
         home: {
@@ -148,14 +150,22 @@ export const actions = {
 
 		// 1. Setup category-related data structures based on the given categories
 		commit("setupCategories", categories);
+
+        // 2. Set the default page as the home page
+        // commit("setCurrentPageNav", "home");		
 	},
 
 	// Tool navigation
 	
 	enablePageNavigation(p_context, p_navData) {
 
-		p_context.commit("setPageNavigation", p_navData);
+		p_context.commit("setPageNavigationAccess", p_navData);
 	},
+
+    setCurrentPage(p_context, p_pageDataKey) {
+
+        p_context.commit("setCurrentPageNav", p_pageDataKey);
+    },	
 
 	// Landing page actions
 	
@@ -280,11 +290,17 @@ export const mutations = {
 
 	// Tool navigation
 
-	setPageNavigation(p_state, p_navData) {
+	setPageNavigationAccess(p_state, p_navData) {
 
 		// Enable or disable access to this page
 		p_state.pageData[p_navData.pageName].accessible = p_navData.enable;
 	},
+
+    setCurrentPageNav(p_state, p_pageDataKey) {
+
+        // Set the current page for the layout navbar
+        p_state.currentPage = p_pageDataKey;
+    },	
 
 	// Landing pages
 

--- a/store/index.js
+++ b/store/index.js
@@ -149,10 +149,7 @@ export const actions = {
 		];
 
 		// 1. Setup category-related data structures based on the given categories
-		commit("setupCategories", categories);
-
-        // 2. Set the default page as the home page
-        // commit("setCurrentPageNav", "home");		
+		commit("setupCategories", categories);	
 	},
 
 	// Tool navigation


### PR DESCRIPTION
A layout vue template has been created in `layouts/default.vue` and `tool-navbar` has been moved outside of the pages and into that default layout.

As such pages are no longer responsible for generating the component and only have to worry about setting the current page via store function `setCurrentPage`.

The store now maintains a member `currentPage` for the navbar component.