### PR TITLE
Adding download page and hooking it into annotation tool workflow

### DIFF
--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -194,7 +194,11 @@ export default {
     },
     columns: {
       type: Object
-    }
+    },
+    pageData: {
+      type: Object,
+      required: true
+    }    
   }
 }
 </script>

--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -194,10 +194,6 @@ export default {
     },
     columns: {
       type: Object
-    },
-    pageData: {
-      type: Object,
-      required: true
     }    
   }
 }

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -183,12 +183,7 @@ export default {
         // we should instead have a separate mechanism to identify missing values
         return ["default category", "missing value"];
       },
-    },
-    pageData: {
-
-        type: Object,
-        required: true
-    }    
+    }  
   },
 };
 </script>

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -184,6 +184,11 @@ export default {
         return ["default category", "missing value"];
       },
     },
+    pageData: {
+
+        type: Object,
+        required: true
+    }    
   },
 };
 </script>

--- a/components/category-age.vue
+++ b/components/category-age.vue
@@ -12,7 +12,6 @@
       :active-category="activeCategoryName"
       :columns="columns"
       :data-table="dataTable"
-      :pageData="pageData"
       @update:dataTable="$emit('update:dataTable', $event)"
     ></annot-age-values>
   </div>
@@ -34,11 +33,7 @@ export default {
     },
     dataTable: {
       type: Array
-    },
-    pageData: {
-      type: Object,
-      required: true
-    }    
+    }   
   }
 }
 </script>

--- a/components/category-age.vue
+++ b/components/category-age.vue
@@ -12,6 +12,7 @@
       :active-category="activeCategoryName"
       :columns="columns"
       :data-table="dataTable"
+      :pageData="pageData"
       @update:dataTable="$emit('update:dataTable', $event)"
     ></annot-age-values>
   </div>
@@ -33,7 +34,11 @@ export default {
     },
     dataTable: {
       type: Array
-    }
+    },
+    pageData: {
+      type: Object,
+      required: true
+    }    
   }
 }
 </script>

--- a/components/category-sex.vue
+++ b/components/category-sex.vue
@@ -12,6 +12,7 @@
       :active-category="activeCategoryName"
       :columns="columns"
       :data-table="dataTable"
+      :pageData="pageData"
       :annotation-options="annotationOptions"
       @update:dataTable="$emit('update:dataTable', $event)"
     >
@@ -37,6 +38,10 @@ export default {
     dataTable: {
       type: Array,
     },
+    pageData: {
+      type: Object,
+      required: true
+    }    
   },
 };
 </script>

--- a/components/category-sex.vue
+++ b/components/category-sex.vue
@@ -12,7 +12,6 @@
       :active-category="activeCategoryName"
       :columns="columns"
       :data-table="dataTable"
-      :pageData="pageData"
       :annotation-options="annotationOptions"
       @update:dataTable="$emit('update:dataTable', $event)"
     >
@@ -37,10 +36,6 @@ export default {
     },
     dataTable: {
       type: Array,
-    },
-    pageData: {
-      type: Object,
-      required: true
     }    
   },
 };

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -3,41 +3,40 @@
     <b-container fluid>
 
         
-            <!--
-                TODO: revisit the client-side render solution or remove this comment
-                The v-for statement below was causing a mismatch between client-side and server-side
-                DOM. In particular, the first element in "pages" (Age) was rendered twice. The error message was:
-                Vue warn]: The client-side rendered virtual DOM tree is not matching server-rendered content.
-                This is likely caused by incorrect HTML markup,
-                for example nesting block-level elements inside <p>, or missing <tbody>.
-                Bailing hydration and performing full client-side render.
+        <!--
+            TODO: revisit the client-side render solution or remove this comment
+            The v-for statement below was causing a mismatch between client-side and server-side
+            DOM. In particular, the first element in "pages" (Age) was rendered twice. The error message was:
+            Vue warn]: The client-side rendered virtual DOM tree is not matching server-rendered content.
+            This is likely caused by incorrect HTML markup,
+            for example nesting block-level elements inside <p>, or missing <tbody>.
+            Bailing hydration and performing full client-side render.
 
-                The best answer I found online was this pretty useless stackoverflow answer:
-                https://stackoverflow.com/a/61375490/1302009 suggesting that this might be due to some
-                async getting of Array data.
-                I forced this block to be rendered client-side only for now and that fixed it for now
-                See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
-            -->
-            <no-ssr>
-            <!-- This gives us built-in keyboard navigation! -->
-            <b-tabs pills card vertical>
-                <!--      TODO: hardcode the pages and just toggle visibility based on state-->
-                <b-tab v-for="page in pages" :title="page.title" :key="page.id">
-                <b-card-text>
-                    <component
-                    :is="page.component"
-                    :columns="columnToCategoryMap"
-                    :dataTable="dataTable.original"
-                    :pageData="pageData"
-                    @remove:column="writeColumn($event)"
-                    @update:dataTable="writeTable($event)"
-                    ></component>
-                </b-card-text>
-                </b-tab>
-            </b-tabs>
-            </no-ssr>
+            The best answer I found online was this pretty useless stackoverflow answer:
+            https://stackoverflow.com/a/61375490/1302009 suggesting that this might be due to some
+            async getting of Array data.
+            I forced this block to be rendered client-side only for now and that fixed it for now
+            See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
+        -->
+        <no-ssr>
+        <!-- This gives us built-in keyboard navigation! -->
+        <b-tabs pills card vertical>
+            <!--      TODO: hardcode the pages and just toggle visibility based on state-->
+            <b-tab v-for="page in pages" :title="page.title" :key="page.id">
+            <b-card-text>
+                <component
+                :is="page.component"
+                :columns="columnToCategoryMap"
+                :dataTable="dataTable.original"
+                :pageData="pageData"
+                @remove:column="writeColumn($event)"
+                @update:dataTable="writeTable($event)"
+                ></component>
+            </b-card-text>
+            </b-tab>
+        </b-tabs>
+        </no-ssr>
         
-
         <b-row>
 
             <b-col cols="9"></b-col>

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -28,7 +28,6 @@
                 :is="page.component"
                 :columns="columnToCategoryMap"
                 :dataTable="dataTable.original"
-                :pageData="pageData"
                 @remove:column="writeColumn($event)"
                 @update:dataTable="writeTable($event)"
                 ></component>
@@ -39,17 +38,17 @@
         
         <b-row>
 
-            <b-col cols="9"></b-col>
+            <b-col cols="7"></b-col>
 
             <!-- Button to proceed to the next page -->
             <!-- Only enabled when at least one annotation table write has been done -->
-            <b-col cols="3">
+            <b-col cols="5">
                 <b-button
                     class="float-right"
                     :disabled="!pageData.download.accessible"
                     :to="'/' + pageData.download.location"
                     :variant="nextPageButtonColor">
-                    Next step: Categorize columns
+                    Next step: Review and download harmonized data
                 </b-button>
             </b-col>
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -1,40 +1,63 @@
 <template>
-  <b-container fluid>
 
-    <!--
-        TODO: revisit the client-side render solution or remove this comment
-        The v-for statement below was causing a mismatch between client-side and server-side
-        DOM. In particular, the first element in "pages" (Age) was rendered twice. The error message was:
-          Vue warn]: The client-side rendered virtual DOM tree is not matching server-rendered content.
-          This is likely caused by incorrect HTML markup,
-          for example nesting block-level elements inside <p>, or missing <tbody>.
-          Bailing hydration and performing full client-side render.
+    <b-container fluid>
 
-        The best answer I found online was this pretty useless stackoverflow answer:
-        https://stackoverflow.com/a/61375490/1302009 suggesting that this might be due to some
-        async getting of Array data.
-        I forced this block to be rendered client-side only for now and that fixed it for now
-        See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
-    -->
-    <no-ssr>
-      <!-- This gives us built-in keyboard navigation! -->
-      <b-tabs pills card vertical>
-        <!--      TODO: hardcode the pages and just toggle visibility based on state-->
-        <b-tab v-for="page in pages" :title="page.title" :key="page.id">
-          <b-card-text>
-            <component
-              :is="page.component"
-              :columns="columnToCategoryMap"
-              :dataTable="dataTable.original"
-              :pageData="pageData"
-              @remove:column="writeColumn($event)"
-              @update:dataTable="writeTable($event)"
-            ></component>
-          </b-card-text>
-        </b-tab>
-      </b-tabs>
-    </no-ssr>
-  </b-container>
+        
+            <!--
+                TODO: revisit the client-side render solution or remove this comment
+                The v-for statement below was causing a mismatch between client-side and server-side
+                DOM. In particular, the first element in "pages" (Age) was rendered twice. The error message was:
+                Vue warn]: The client-side rendered virtual DOM tree is not matching server-rendered content.
+                This is likely caused by incorrect HTML markup,
+                for example nesting block-level elements inside <p>, or missing <tbody>.
+                Bailing hydration and performing full client-side render.
+
+                The best answer I found online was this pretty useless stackoverflow answer:
+                https://stackoverflow.com/a/61375490/1302009 suggesting that this might be due to some
+                async getting of Array data.
+                I forced this block to be rendered client-side only for now and that fixed it for now
+                See: https://nuxtjs.org/docs/features/nuxt-components/#the-client-only-component
+            -->
+            <no-ssr>
+            <!-- This gives us built-in keyboard navigation! -->
+            <b-tabs pills card vertical>
+                <!--      TODO: hardcode the pages and just toggle visibility based on state-->
+                <b-tab v-for="page in pages" :title="page.title" :key="page.id">
+                <b-card-text>
+                    <component
+                    :is="page.component"
+                    :columns="columnToCategoryMap"
+                    :dataTable="dataTable.original"
+                    :pageData="pageData"
+                    @remove:column="writeColumn($event)"
+                    @update:dataTable="writeTable($event)"
+                    ></component>
+                </b-card-text>
+                </b-tab>
+            </b-tabs>
+            </no-ssr>
+        
+
+        <b-row>
+
+            <b-col cols="9"></b-col>
+
+            <!-- Button to proceed to the next page -->
+            <!-- Only enabled when at least one annotation table write has been done -->
+            <b-col cols="3">
+                <b-button
+                    class="float-right"
+                    :disabled="!pageData.download.accessible"
+                    :to="'/' + pageData.download.location"
+                    :variant="nextPageButtonColor">
+                    Next step: Categorize columns
+                </b-button>
+            </b-col>
+
+        </b-row>
+
+
+    </b-container>
 </template>
 
 <script>
@@ -57,11 +80,18 @@ export default {
     };
   },
   computed: {
+
     ...mapState([
       "columnToCategoryMap",
       "dataTable",
       "pageData"
     ]),
+
+    nextPageButtonColor() {
+
+        // Bootstrap variant color of the button leading to the categorization page
+        return this.pageData.download.accessible ? "success" : "secondary"
+    }    
   },
   methods: {
     writeColumn(event) {
@@ -73,22 +103,27 @@ export default {
       // Unlink this column from its current category
       this.$store.dispatch("unlinkColumnWithCategory", { column: event.removedColumn });
     },
+
     writeTable(event) {
-      console.log(
-        "On the Annotation page, I got an updated datatable:",
-        event.transformedTable
-      );
-      console.log(
-        "I also got the corresponding transformations:",
-        event.transformHeuristics
-      );
 
-      // 1. Save the annotated table in the store
-      this.$store.dispatch("saveAnnotatedDataTable", event.transformedTable);
+        console.log(
+            "On the Annotation page, I got an updated datatable:",
+            event.transformedTable
+        );
+        console.log(
+            "I also got the corresponding transformations:",
+            event.transformHeuristics
+        );
 
-      // 2. Programmatically navigate to download page
-      // NOTE: This is done because the 'to' attribute on button overrides the @click event
-      this.$router.push("/" + this.pageData.download.location);
+        // 1. Save the annotated table in the store
+        this.$store.dispatch("saveAnnotatedDataTable", event.transformedTable);
+
+        // 2. Enable the download page when the annotated data table has been written
+        this.$store.dispatch("enablePageNavigation", {
+            
+            pageName: "download",
+            enable: true
+        });      
     },
   },
 
@@ -96,13 +131,6 @@ export default {
 
         // 1. Set the current page name
         this.$store.dispatch("setCurrentPage", "annotation");
-
-        // 2. Enable the download page automatically
-        this.$store.dispatch("enablePageNavigation", {
-        	
-					  pageName: "download",
-					  enable: true
-				});
     }
 
 };

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -26,6 +26,7 @@
               :is="page.component"
               :columns="columnToCategoryMap"
               :dataTable="dataTable.original"
+              :pageData="pageData"
               @remove:column="writeColumn($event)"
               @update:dataTable="writeTable($event)"
             ></component>
@@ -82,8 +83,12 @@ export default {
         event.transformHeuristics
       );
 
-      // Save the annotated table in the store
+      // 1. Save the annotated table in the store
       this.$store.dispatch("saveAnnotatedDataTable", event.transformedTable);
+
+      // 2. Programmatically navigate to download page
+      // NOTE: This is done because the 'to' attribute on button overrides the @click event
+      this.$router.push("/" + this.pageData.download.location);
     },
   },
 
@@ -91,6 +96,13 @@ export default {
 
         // 1. Set the current page name
         this.$store.dispatch("setCurrentPage", "annotation");
+
+        // 2. Enable the download page automatically
+        this.$store.dispatch("enablePageNavigation", {
+        	
+					  pageName: "download",
+					  enable: true
+				});
     }
 
 };

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -1,0 +1,144 @@
+<template>
+
+    <div>
+
+        <b-row >
+
+            <b-table
+                bordered
+                outlined
+                sticky-header
+                head-variant="dark"
+                :items="dataTable.annotated">
+            </b-table>
+            <!-- Debug component - shows file contents -->
+            <!-- <textarea :rows="textArea.width" :cols="textArea.height" v-model="stringifiedDataTable"></textarea> -->
+        </b-row>
+
+        <b-row>
+
+            <b-col cols="9"></b-col>
+
+            <!-- Button to proceed to download the annotation output data -->
+			<!-- Only enabled when annotation has been at least partially completed -->
+			<b-col cols="3">
+				<b-button
+					class="float-right"
+					:disabled="!isAnnotatedDataTableLoaded"
+					:variant="downloadButtonColor">
+					Download Annotated Data
+				</b-button>
+			</b-col>
+        
+        </b-row>
+
+    </div>
+
+</template>
+
+<script>
+
+	// Allows for reference to store data by creating simple, implicit getters
+	import { mapState } from "vuex";
+    import { mapGetters } from "vuex";
+
+    export default {
+
+        data() {
+
+            return {
+
+				// Size of the file display textboxes
+				textArea: {
+
+					width: 5,
+					height: 800
+				}
+
+            };
+        },
+
+        computed: {
+
+            ...mapState([
+
+				"dataTable",
+				"pageData"
+			]),
+
+            ...mapGetters([
+
+                "isAnnotatedDataTableLoaded"
+            ]),
+
+			downloadButtonColor() {
+
+				// Bootstrap variant color of the button leading to the output download
+				return this.isAnnotatedDataTableLoaded ? "success" : "secondary"
+			},
+
+            fields() {
+
+                if ( !this.isAnnotatedDataTableLoaded ) {
+                    return [];
+                }
+
+                let fieldsArray = [];
+                for ( let column of Object.keys(this.dataTable.annotated[0]) ) {
+                    fieldsArray.push({ key: column });
+                }
+                return fieldsArray;
+            },
+
+			stringifiedDataTable() {
+
+				// 0. Return a blank string is there is no loaded data table
+				if ( !this.isAnnotatedDataTableLoaded ) {
+					return "";
+				}
+
+				// 1. Convert the tsv file data into a list of strings
+				// NOTE: Defaults to tsv for now
+				let textAreaArray = [Object.keys(this.dataTable.annotated[0]).join("\t")];
+				for ( let index = 0; index < Object.keys(this.dataTable.annotated[0]).length; index++ ) {
+					textAreaArray.push(Object.values(this.dataTable.annotated[index]).join("\t"));
+				}
+
+				// 2. Return the tsv file data joined as one string
+				return textAreaArray.join("\n");
+			}            
+        },
+
+        methods: {
+
+            saveFile() {
+
+                // 1. Create a blob out of the annotated table data           
+                const data = JSON.stringify(this.dataTable.annotated)
+                const blob = new Blob([data], {type: "text/plain"})
+    
+                // 2. Create an anchor tag in memory linked to the blob
+                const pseudoAnchor = document.createElement("a");
+                pseudoAnchor.download = "annotated_data.json";
+                pseudoAnchor.href = window.URL.createObjectURL(blob);
+                pseudoAnchor.dataset.downloadurl = [
+                    "text/json",
+                    pseudoAnchor.download,
+                    pseudoAnchor.href
+                ].join(':');
+                
+                // 3. Dispatch a mouse click event on the in-memory anchor tag
+                const pseudoClickEvent = document.createEvent("MouseEvents");
+                pseudoClickEvent.initEvent("click", true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+                pseudoAnchor.dispatchEvent(pseudoClickEvent);
+            }
+        },
+
+        mounted() {
+
+            // 1. Set the current page
+            this.$store.dispatch("setCurrentPage", "download");
+        }
+    }
+
+</script>

--- a/store/index.js
+++ b/store/index.js
@@ -352,6 +352,11 @@ export const getters = {
 		return p_state.categories;
 	},
 
+	isAnnotatedDataTableLoaded(p_state) {
+
+		return ( null != p_state.dataTable.annotated );
+	},	
+
 	isColumnLinkedToCategory: (p_state) => (p_matchData) => {
 
 		// Check to see if the given column has been linked to the given category


### PR DESCRIPTION
This PR adds a basic download page that follows the annotation page. 

Currently it is always accessible from the annotation page (not unlocked upon completion of annotation - like the other pages). This is just for demo purposes. Going to the download page while in the annotation page without having 'annotated' any data merely produces a blank page with "download" button.

However, once an annotation has occurred, going to the download page produces a table of the "annotated" data.

NOTE: Some other aspects of this implementation should be revisited after the demo tomorrow - including how/when annotation status is saved in the store. This will include moving replicated functionality like the 'Confirm and Upload' button upwards out of the annotation page's components.