### PR TITLE
[FEAT] add vocabulary annotation

### DIFF
--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -1,0 +1,141 @@
+<template>
+  <div>
+    <b-card no-body>
+      <b-card-header>I am a vocabulary header</b-card-header>
+      <b-card-body>
+        <b-table :items="displayTable" :fields="exampleFields">
+          <template #cell(select_a_vocabulary_term)="row">
+            <b-form-input
+              id="input-live"
+              v-model="things[row.item.column_name]"
+              :state="vocabState"
+              aria-describedby="input-live-help input-live-feedback"
+              placeholder="enter the SNOMED-CT URI here"
+              trim
+              @input="doSomething($event, row.item)"
+            ></b-form-input>
+
+            <!--             This will only be shown if the preceding input has an invalid state -->
+            <!--            <b-form-invalid-feedback id="input-live-feedback">-->
+            <!--              Enter at least 3 letters-->
+            <!--            </b-form-invalid-feedback>-->
+
+            <!-- This is a form text block (formerly known as help block) -->
+            <b-form-text id="input-live-help"
+              >Please provide a SNOMED-CT term.</b-form-text
+            >
+          </template>
+        </b-table>
+      </b-card-body>
+    </b-card>
+    <b-button variant="success" @click="uploadMappings"
+      >Confirm and Upload</b-button
+    >
+  </div>
+</template>
+
+<script>
+// TODO: merge this component with the vocabulary component
+export default {
+  name: "AnnotVocabulary",
+  data() {
+    return {
+      things: {},
+      vocabState: null,
+    };
+  },
+  computed: {
+    relevantColumns() {
+      //  Return only those columns that are annotated with the current category
+      return Object.entries(this.columns)
+        .filter(
+          ([columnName, categoryName]) => categoryName === this.activeCategory
+        )
+        .map((element) => element[0]); // return only the column name that was assigned to this.activeCategory
+    },
+    exampleFields() {
+      let defaultFields =  ["column_name", "select_a_vocabulary_term"];
+      if (this.mode === "column") {
+        return defaultFields;
+      }
+      return  ["column_name", "raw_value", "select_a_vocabulary_term"];
+    },
+    filteredTable() {
+      // We return a datatable where each row is filtered to only show the columns that are mapped to the active category
+      return this.dataTable.map((row) => {
+        return Object.fromEntries(
+          Object.entries(row).filter(([columnName, _rowValue]) =>
+            this.relevantColumns.includes(columnName)
+          )
+        );
+      });
+    },
+    uniqueValues() {
+      // Extract array of unique values from filteredTable, keyed on the column names
+      return Object.fromEntries(
+        this.relevantColumns.map((colName) => {
+          const uniques = new Set(
+            this.filteredTable.map((row) => row[colName])
+          );
+          return [colName, Array.from(uniques)];
+        })
+      );
+    },
+    displayTable() {
+      return this.relevantColumns
+        .map((colName) => {
+
+          // If we are in column mode, we don't need to render individual values
+          if (this.mode === "column") {
+            return { column_name: colName };
+
+          //  For row mode, we need the individual (unique) values of the relevant columns
+          } else if (this.mode === "row") {
+            return this.uniqueValues[colName].map((value) => {
+              return {
+                column_name: colName,
+                raw_value: value,
+              };
+            });
+          }
+        })
+        .flat();
+    },
+  },
+  methods: {
+    doSomething(event, row) {
+      console.log("I am doing something with:", event, "in", row.column_name);
+      this.things[row.column_name] = event;
+    },
+    determineState(valueName) {},
+    uploadMappings() {
+      this.$emit("update:heuristics", {
+        heuristic: this.things,
+      }),
+        console.log("uploaded diagnosis heuristics");
+    },
+  },
+  props: {
+    columns: {
+      type: Object,
+      required: true,
+    },
+    dataTable: {
+      type: Array,
+      required: false,
+    },
+    activeCategory: {
+      type: String,
+    },
+    mode: {
+      // one of [ "column", "row" ]
+      // column: only the column names are mapped to vocabulary terms inside the data dictionary
+      // row: the row values are mapped to vocabulary terms
+      type: String,
+      default: "row",
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -9,7 +9,7 @@
               id="input-live"
               :state="vocabState"
               aria-describedby="input-live-help input-live-feedback"
-              placeholder="enter the SNOMED-CT URI here"
+              :placeholder="placeholder"
               trim
               @input="doSomething($event, row.item)"
             ></b-form-input>
@@ -20,15 +20,15 @@
 
             <!-- This is a form text block (formerly known as help block) -->
             <b-form-text id="input-live-help"
-              >Please provide a SNOMED-CT term.</b-form-text
-            >
+              >{{instruction}}
+            </b-form-text>
           </template>
         </b-table>
       </b-card-body>
     </b-card>
     <b-button variant="success" @click="uploadMappings"
-      >Confirm and Upload</b-button
-    >
+      >Confirm and Upload
+    </b-button>
   </div>
 </template>
 
@@ -43,6 +43,24 @@ export default {
     };
   },
   computed: {
+    placeholder() {
+      if (this.mode === "column") {
+        return "e.g. MoCA"
+      } else if (this.mode === "row") {
+        return "e.g. Parkinson's Disease"
+      } else {
+        return ""
+      }
+    },
+    instruction() {
+      if (this.mode === "column") {
+        return "Please provide a reproschema term"
+      } else if (this.mode === "row") {
+        return "Please provide a SNOMED-CT term"
+      } else {
+        return "Please provide an appropriate vocabulary term"
+      }
+    },
     relevantColumns() {
       //  Return only those columns that are annotated with the current category
       return Object.entries(this.columns)
@@ -52,11 +70,20 @@ export default {
         .map((element) => element[0]); // return only the column name that was assigned to this.activeCategory
     },
     exampleFields() {
-      let defaultFields =  ["column_name", "description", "select_a_vocabulary_term"];
+      let defaultFields = [
+        "column_name",
+        "description",
+        "select_a_vocabulary_term",
+      ];
       if (this.mode === "column") {
         return defaultFields;
       }
-      return  ["column_name", "raw_value", "description", "select_a_vocabulary_term"];
+      return [
+        "column_name",
+        "raw_value",
+        "description",
+        "select_a_vocabulary_term",
+      ];
     },
     filteredTable() {
       // We return a datatable where each row is filtered to only show the columns that are mapped to the active category
@@ -82,21 +109,26 @@ export default {
     displayTable() {
       return this.relevantColumns
         .map((colName) => {
-
           // If we are in column mode, we don't need to render individual values
           if (this.mode === "column") {
             return {
               column_name: colName,
-              description: this.getDescription(colName)[0] === undefined ? "" : this.getDescription(colName)[0]
+              description:
+                this.getDescription(colName)[0] === undefined
+                  ? ""
+                  : this.getDescription(colName)[0],
             };
 
-          //  For row mode, we need the individual (unique) values of the relevant columns
+            //  For row mode, we need the individual (unique) values of the relevant columns
           } else if (this.mode === "row") {
             return this.uniqueValues[colName].map((value) => {
               return {
                 column_name: colName,
                 raw_value: value,
-                description: this.getDescription(colName, value)[1] === undefined ? "" : this.getDescription(colName, value)[1]
+                description:
+                  this.getDescription(colName, value)[1] === undefined
+                    ? ""
+                    : this.getDescription(colName, value)[1],
               };
             });
           }
@@ -120,17 +152,35 @@ export default {
       let valueDescription = undefined;
 
       // If we do not have a data dictionary then the descriptions are undefined
-      if (this.dataDictionary === null || typeof this.dataDictionary !== "object" || columnName === undefined) {
+      if (
+        this.dataDictionary === null ||
+        typeof this.dataDictionary !== "object" ||
+        columnName === undefined
+      ) {
         return [columnDescription, valueDescription];
-
       } else if (Object.keys(this.dataDictionary).includes(columnName)) {
         const columnDict = this.dataDictionary[columnName];
-        columnDescription = columnDict[Object.keys(columnDict).find(key => key.toLowerCase() === "description")];
+        columnDescription =
+          columnDict[
+            Object.keys(columnDict).find(
+              (key) => key.toLowerCase() === "description"
+            )
+          ];
 
         if (value !== null) {
-          const columnLevels = columnDict[Object.keys(columnDict).find(key => key.toLowerCase() === "levels")];
+          const columnLevels =
+            columnDict[
+              Object.keys(columnDict).find(
+                (key) => key.toLowerCase() === "levels"
+              )
+            ];
           if (columnLevels !== undefined) {
-            valueDescription = columnLevels[Object.keys(columnLevels).find(key => key.toLowerCase() === value.toLowerCase())];
+            valueDescription =
+              columnLevels[
+                Object.keys(columnLevels).find(
+                  (key) => key.toLowerCase() === value.toLowerCase()
+                )
+              ];
           }
         }
       }
@@ -149,7 +199,7 @@ export default {
     dataDictionary: {
       type: Object,
       required: false,
-      default: null
+      default: null,
     },
     activeCategory: {
       type: String,

--- a/components/category-assessment.vue
+++ b/components/category-assessment.vue
@@ -7,6 +7,13 @@
       :active-category="activeCategoryName"
       @remove:column="$emit('remove:column', $event)"
     ></annot-columns>
+
+    <annot-vocabulary
+      :active-category="activeCategoryName"
+      :columns="columns"
+      @update:heuristics="$emit('update:heuristics', $event)"
+      :mode="`column`"
+    ></annot-vocabulary>
   </div>
 </template>
 

--- a/components/category-assessment.vue
+++ b/components/category-assessment.vue
@@ -12,6 +12,7 @@
       :active-category="activeCategoryName"
       :columns="columns"
       @update:heuristics="$emit('update:heuristics', $event)"
+      :dataDictionary="dataDictionary"
       :mode="`column`"
     ></annot-vocabulary>
   </div>
@@ -30,6 +31,11 @@ export default {
     columns: {
       type: Object,
       required: true
+    },
+    dataDictionary: {
+      type: Object,
+      required: false,
+      default: null
     },
   }
 };

--- a/components/category-diagnosis.vue
+++ b/components/category-diagnosis.vue
@@ -7,6 +7,13 @@
       :active-category="activeCategoryName"
       @remove:column="$emit('remove:column', $event)"
     ></annot-columns>
+
+    <annot-vocabulary
+      :active-category="activeCategoryName"
+      :columns="columns"
+      :data-table="dataTable"
+      @update:heuristics="$emit('update:heuristics', $event)"
+    ></annot-vocabulary>
   </div>
 </template>
 
@@ -23,6 +30,9 @@ export default {
     columns: {
       type: Object,
       required: true
+    },
+    dataTable: {
+      type: Array,
     },
   }
 };

--- a/components/category-diagnosis.vue
+++ b/components/category-diagnosis.vue
@@ -14,6 +14,7 @@
       :data-table="dataTable"
       :dataDictionary="dataDictionary"
       @update:heuristics="$emit('update:heuristics', $event)"
+      @update:dataTable="$emit('update:dataTable', $event)"
     ></annot-vocabulary>
   </div>
 </template>

--- a/components/category-diagnosis.vue
+++ b/components/category-diagnosis.vue
@@ -12,6 +12,7 @@
       :active-category="activeCategoryName"
       :columns="columns"
       :data-table="dataTable"
+      :dataDictionary="dataDictionary"
       @update:heuristics="$emit('update:heuristics', $event)"
     ></annot-vocabulary>
   </div>
@@ -33,6 +34,11 @@ export default {
     },
     dataTable: {
       type: Array,
+    },
+    dataDictionary: {
+      type: Object,
+      required: false,
+      default: null
     },
   }
 };

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -2,12 +2,12 @@
   <b-container fluid>
 
     <!--
-        TODO: revisit the client-side render solution or remove this comment
+        TODO: revisit the client-side render solution or remove but didn't have itthis comment
         The v-for statement below was causing a mismatch between client-side and server-side
         DOM. In particular, the first element in "pages" (Age) was rendered twice. The error message was:
           Vue warn]: The client-side rendered virtual DOM tree is not matching server-rendered content.
           This is likely caused by incorrect HTML markup,
-          for example nesting block-level elements inside <p>, or missing <tbody>.
+          for example nesting bannotationlock-level elements inside <p>, or missing <tbody>.
           Bailing hydration and performing full client-side render.
 
         The best answer I found online was this pretty useless stackoverflow answer:
@@ -26,6 +26,7 @@
               :is="page.component"
               :columns="columnToCategoryMap"
               :dataTable="dataTable.original"
+              :dataDictionary="dataDictionary.original"
               @remove:column="writeColumn($event)"
               @update:dataTable="writeTable($event)"
             ></component>
@@ -59,6 +60,7 @@ export default {
     ...mapState([
       "columnToCategoryMap",
       "dataTable",
+      "dataDictionary",
       "pageData"
     ]),
   },

--- a/store/index.js
+++ b/store/index.js
@@ -404,7 +404,12 @@ function convertTsvLinesToDict(p_tsvLines){
 		}
 
 		// B. Save the row dictionary
-		tsvRowDictArray.push(tsvRowDict);
+		// NOTE: Conditional here is to account for the possibility of a blank line
+		// among the tsv lines input to this function. We may want to readdress this
+		// via the Papa parse file input method or just leave as is
+		if ( Object.keys(tsvRowDict).length > 0 ) {
+			tsvRowDictArray.push(tsvRowDict);
+		}
 	}
 
 	return tsvRowDictArray;


### PR DESCRIPTION
This PR adds a new annotation component (annot-vocabulary.vue) for
- diagnosis
- assessment tools

annotation.
The functionality at the moment is limited to freeform text fields without validation. 
For diagnosis,  every unique value is displayed and can be mapped to a term. The tooltip suggestions ask for SNOMED-CT.
For assessment tools, every column name labeled as "about assessment" can be mapped to a term, and no unique values are shown.

Closes https://github.com/metaneuro/annotation_tool/issues/63

Known limitations:
- the provided mappings are not (yet) tied to the global app state. So navigating away and back to the annotation page will reset all text fields
- similarly, the mappings (unique value -> vocabulary term, and column Name -> vocabulary term) are not emitted to the parent components. Thus: the data dictionary does not get updated based on these mappings (yet)
- because of the above, annotating assessment tools currently does not affect the app outside of the annotation page (no unique values to update in the data table, and heuristics are not emitted). In a future iteration, we'll want to use the mappings of the annotation columns to update the data dictionary
- there is no validation on the input data (although the code is prepared and commented out). Even for this preliminary version (where we do not actively search vocabularies but just provide text fields), we should validate the input to check that we get valid vocabulary URIs. This is not yet implemented, so any text input is valid at the moment
- there is a lot of code duplication between this component and the ones used for age and sex.
