### PR TITLE
[FIX] pass the original and annotated dataTable to components

### DIFF
--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -191,7 +191,7 @@ export default {
   },
   props: {
     dataTable: {
-      type: Array,
+      type: Object,
       required: true
     },
     activeCategory: {

--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -42,8 +42,10 @@ export default {
         .map(element => element[0]) // return only the column name that was assigned to this.activeCategory
     },
     filteredTable() {
+      // We want to use the origina dataTable here because we want to display the original raw values
+
       // We return a datatable where each row is filtered to only show the columns that are mapped to the active category
-      return this.dataTable.map(row => {
+      return this.dataTable.original.map(row => {
           return Object.fromEntries(
             Object.entries(row)
               .filter(
@@ -162,7 +164,10 @@ export default {
       // TODO: we need to be able to handle bad values being passed here
       // Applies the currently stored transform heuristics to the input dataTable to make the results
       // available outside the component
-      const transformedTable = this.dataTable.map(row => {
+
+      // We want to use the annotated dataTable here in order to not overwrite previous
+      // annotations from other components
+      const transformedTable = this.dataTable.annotated.map(row => {
           return Object.fromEntries(
             Object.entries(row).map(
               ([colName, value]) => {
@@ -194,7 +199,7 @@ export default {
     },
     columns: {
       type: Object
-    }    
+    }
   }
 }
 </script>

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -54,8 +54,10 @@ export default {
         .map((element) => element[0]); // return only the column name that was assigned to this.activeCategory
     },
     filteredTable() {
+      // We want to use the origina dataTable here because we want to display the original raw values
+
       // We return a datatable where each row is filtered to only show the columns that are mapped to the active category
-      return this.dataTable.map((row) => {
+      return this.dataTable.original.map((row) => {
         return Object.fromEntries(
           Object.entries(row).filter(([columnName, _rowValue]) =>
             this.relevantColumns.includes(columnName)
@@ -127,7 +129,9 @@ export default {
       );
     },
     applyTransform() {
-      const transformedTable = this.dataTable.map((row) => {
+      // We want to use the annotated dataTable here in order to not overwrite previous
+      // annotations from other components
+      const transformedTable = this.dataTable.annotated.map((row) => {
         return Object.fromEntries(
           Object.entries(row).map(([colName, value]) => {
             if (this.relevantColumns.includes(colName)) {
@@ -183,7 +187,7 @@ export default {
         // we should instead have a separate mechanism to identify missing values
         return ["default category", "missing value"];
       },
-    }  
+    }
   },
 };
 </script>

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -169,7 +169,7 @@ export default {
   },
   props: {
     dataTable: {
-      type: Array,
+      type: Object,
       required: true,
     },
     activeCategory: {

--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -267,7 +267,7 @@ export default {
       required: true,
     },
     dataTable: {
-      type: Array,
+      type: Object,
       required: false,
     },
     dataDictionary: {

--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -92,8 +92,10 @@ export default {
       ];
     },
     filteredTable() {
+      // We want to use the origina dataTable here because we want to display the original raw values
+
       // We return a datatable where each row is filtered to only show the columns that are mapped to the active category
-      return this.dataTable.map((row) => {
+      return this.dataTable.original.map((row) => {
         return Object.fromEntries(
           Object.entries(row).filter(([columnName, _rowValue]) =>
             this.relevantColumns.includes(columnName)
@@ -200,7 +202,9 @@ export default {
           transformHeuristics: this.vocabularyMapping,
         });
       } else if (this.mode === "row") {
-        const transformedTable = this.dataTable.map((row) => {
+        // We want to use the annotated dataTable here in order to not overwrite previous
+        // annotations from other components
+        const transformedTable = this.dataTable.annotated.map((row) => {
           return Object.fromEntries(
             Object.entries(row).map(([colName, value]) => {
               if (this.relevantColumns.includes(colName)) {

--- a/components/category-age.vue
+++ b/components/category-age.vue
@@ -32,8 +32,9 @@ export default {
       required: true
     },
     dataTable: {
-      type: Array
-    }   
+      type: Object,
+      required: true
+    }
   }
 }
 </script>

--- a/components/category-diagnosis.vue
+++ b/components/category-diagnosis.vue
@@ -34,7 +34,8 @@ export default {
       required: true
     },
     dataTable: {
-      type: Array,
+      type: Object,
+      required: true
     },
     dataDictionary: {
       type: Object,

--- a/components/category-sex.vue
+++ b/components/category-sex.vue
@@ -35,8 +35,9 @@ export default {
       required: true,
     },
     dataTable: {
-      type: Array,
-    }    
+      type: Object,
+      required: true
+    }
   },
 };
 </script>

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -25,7 +25,7 @@
             <component
               :is="page.component"
               :columns="columnToCategoryMap"
-              :dataTable="dataTable.original"
+              :dataTable="dataTable"
               :dataDictionary="dataDictionary.original"
               @remove:column="writeColumn($event)"
               @update:dataTable="writeTable($event)"

--- a/store/index.js
+++ b/store/index.js
@@ -311,6 +311,9 @@ export const mutations = {
 
 		// 3. Save a list of the columns of this data table
 		p_state.dataTable.columns = p_newFileData.columns;
+
+		// 4. Make the annotated data a copy of the original
+		p_state.dataTable.annotated = structuredClone(p_state.dataTable.original);
 	},
 
 	setDataDictionary(p_state, p_newFileData) {


### PR DESCRIPTION
- Components get as props both the original dataTable and the annotated dataTable
- inside components the updated mappings of values are applied to the annotated dataTable in order not to lose previous annotations
- raw values are still displayed based on the original dataTable.

Fixes: #94