### PR TITLE
Changing annotation table status check to see if it differs from original table

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -24,7 +24,7 @@
 			<b-col cols="3">
 				<b-button
 					class="float-right"
-					:disabled="!isAnnotatedDataTableLoaded"
+					:disabled="!isDataAnnotated"
 					:variant="downloadButtonColor">
 					Download Annotated Data
 				</b-button>
@@ -68,18 +68,18 @@
 
             ...mapGetters([
 
-                "isAnnotatedDataTableLoaded"
+                "isDataAnnotated"
             ]),
 
 			downloadButtonColor() {
 
 				// Bootstrap variant color of the button leading to the output download
-				return this.isAnnotatedDataTableLoaded ? "success" : "secondary"
+				return this.isDataAnnotated ? "success" : "secondary"
 			},
 
             fields() {
 
-                if ( !this.isAnnotatedDataTableLoaded ) {
+                if ( !this.isDataAnnotated ) {
                     return [];
                 }
 
@@ -93,7 +93,7 @@
 			stringifiedDataTable() {
 
 				// 0. Return a blank string is there is no loaded data table
-				if ( !this.isAnnotatedDataTableLoaded ) {
+				if ( !this.isDataAnnotated ) {
 					return "";
 				}
 

--- a/store/index.js
+++ b/store/index.js
@@ -353,11 +353,6 @@ export const getters = {
 	categories(p_state) {
 
 		return p_state.categories;
-	},
-
-	isAnnotatedDataTableLoaded(p_state) {
-
-		return ( null != p_state.dataTable.annotated );
 	},	
 
 	isColumnLinkedToCategory: (p_state) => (p_matchData) => {
@@ -365,6 +360,27 @@ export const getters = {
 		// Check to see if the given column has been linked to the given category
 		return ( p_matchData.category === p_state.columnToCategoryMap[p_matchData.column] );
 	},
+
+	isDataAnnotated(p_state) {
+
+		// 1. Compare each row in the original and annotated tables
+		// NOTE: If any value is unequal, the data is considered 'annotated'
+		// We will likely want to revisit this qualification
+		for ( let originalRow of p_state.dataTable.original ) {
+			for ( let annotatedRow of p_state.dataTable.annotated ) {
+
+				// A. Check for unequal column values between the original and annotated tables
+				for ( let column in originalRow ) {
+					if ( annotatedRow[column] != originalRow[column] ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		// If all values in the tables are equal, data has not yet been annotated
+		return false;
+	},	
 
 	isDataDictionaryLoaded(p_state) {
 


### PR DESCRIPTION
The current condition we accept for an annotation to have occurred - and thus the download of a file to be available on the download page - is if any value in the annotated data table differs from its counterpart in the original data table.