### PR TITLE
Styling improvements for demo

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10,28 +10,28 @@
 
 .category-style-0 {
 
-	background-color: rgb(164,208,90);
-	color: black;
+	background-color: rgb(164,208,90) !important;
+	color: black !important;
 }
 .category-style-1 {
 	
-	background-color: rgb(127,23,167);
-	color: white;
+	background-color: rgb(127,23,167) !important;
+	color: white !important;
 }
 .category-style-2 {
 	
-	background-color: rgb(70,76,174);
-	color: white;		
+	background-color: rgb(70,76,174) !important;
+	color: white !important;		
 }
 .category-style-3 {
 	
-	background-color: rgb(236,197,50);
-	color: black;
+	background-color: rgb(236,197,50) !important;
+	color: black !important;
 }
 .category-style-4 {
 	
-	background-color: rgb(128,1,1);
-	color: white;	
+	background-color: rgb(128,1,1) !important;
+	color: white !important;	
 }
 
 .category-style-default {
@@ -52,4 +52,19 @@
 	margin: 1em;
 	padding-left: 2em;
 	padding-right: 2em;
+}
+
+/* Annotation page styles */
+
+.annotation-card {
+	margin-bottom: 1em;
+}
+
+.annotation-tab-nav {
+	margin-bottom: 1em;
+	opacity: 0.5;
+}
+
+.annotation-tab-nav.active{
+	opacity: 1.0;
 }

--- a/components/annot-age-values.vue
+++ b/components/annot-age-values.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
-    <b-card no-body>
-      <b-card-header>I am a header</b-card-header>
+    <b-card no-body class="annotation-card">
+      <b-card-header>Review the age harmonization</b-card-header>
       <b-card-body style="position:relative; height:300px; overflow-y:scroll;">
         <annot-continuous-values :items="unique_table_data"></annot-continuous-values>
       </b-card-body>
     </b-card>
-    <b-button variant="success" @click="applyTransform">Confirm and Upload</b-button>
+    <b-button variant="success" @click="applyTransform">Save Annotation</b-button>
   </div>
 </template>
 

--- a/components/annot-columns.vue
+++ b/components/annot-columns.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card no-body>
+  <b-card no-body class="annotation-card">
     <!--    TODO: make this also toggleable like the explanation tab-->
     <b-card-header>Review the annotated columns</b-card-header>
     <b-card-body style="height:30vh; overflow-y:scroll;">

--- a/components/annot-discrete-choices.vue
+++ b/components/annot-discrete-choices.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <b-card no-body>
-      <b-card-header>I am a header</b-card-header>
+    <b-card no-body class="annotation-card">
+      <b-card-header>Annotate each unique value</b-card-header>
       <b-card-body>
-        <b-table :items="displayTable" :fields="exampleFields">
+        <b-table striped :items="displayTable" :fields="exampleFields">
           <template #cell(select_an_appropriate_mapping)="row">
             <!--Bootstrap-Vue doesn't have a great option here so I am using https://vue-select.org/-->
             <!--Note: we use the $event statement to add the row data to the payload of the @input
@@ -16,10 +16,10 @@
           </template>
         </b-table>
         <b-button
-          variant="success"
           @click="applyTransform"
           :disabled="buttonDisabled"
-          >Confirm and Upload
+          :variant="saveAnnotationButtonColor">
+          Save Annotation
         </b-button>
       </b-card-body>
     </b-card>
@@ -65,6 +65,13 @@ export default {
         );
       });
     },
+    
+    saveAnnotationButtonColor() {
+
+        // Bootstrap variant color of the button to save the annotation to the data table
+        return ( !this.buttonDisabled ) ? "success" : "secondary"
+    },
+
     uniqueValues() {
       // Extract array of unique values from filteredTable, keyed on the column names
       return Object.fromEntries(

--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
-    <b-card no-body>
-      <b-card-header>I am a vocabulary header</b-card-header>
+    <b-card no-body class="annotation-card">
+      <b-card-header>Annotate each unique value</b-card-header>
       <b-card-body>
-        <b-table :items="displayTable" :fields="exampleFields" fixed>
+        <b-table striped :items="displayTable" :fields="exampleFields" fixed>
           <template #cell(select_a_vocabulary_term)="row">
             <b-form-input
               id="input-live"
@@ -23,10 +23,10 @@
           </template>
         </b-table>
         <b-button
-          variant="success"
           @click="uploadVocabularyMappings"
           :disabled="buttonDisabled"
-          >Confirm and Upload
+          :variant="saveAnnotationButtonColor">
+          Confirm and Upload
         </b-button>
       </b-card-body>
     </b-card>
@@ -75,6 +75,13 @@ export default {
         )
         .map((element) => element[0]); // return only the column name that was assigned to this.activeCategory
     },
+
+    saveAnnotationButtonColor() {
+
+        // Bootstrap variant color of the button to save the annotation to the data table
+        return ( !this.buttonDisabled ) ? "success" : "secondary"
+    },
+
     exampleFields() {
       let defaultFields = [
         "column_name",

--- a/components/annot-vocabulary.vue
+++ b/components/annot-vocabulary.vue
@@ -26,7 +26,7 @@
           @click="uploadVocabularyMappings"
           :disabled="buttonDisabled"
           :variant="saveAnnotationButtonColor">
-          Confirm and Upload
+          Save Annotation
         </b-button>
       </b-card-body>
     </b-card>

--- a/components/tool-navbar.vue
+++ b/components/tool-navbar.vue
@@ -46,7 +46,7 @@
 
             return {
                 
-                toolName: "Origami Annotation Tool"
+                toolName: "Annotation Tool"
             }
         },
 

--- a/pages/annotation.vue
+++ b/pages/annotation.vue
@@ -18,9 +18,18 @@
     -->
     <no-ssr>
       <!-- This gives us built-in keyboard navigation! -->
-      <b-tabs pills card vertical>
+      <b-tabs
+        pills
+        card 
+        vertical
+        v-model="tabNavTitle">
+
         <!--      TODO: hardcode the pages and just toggle visibility based on state-->
-        <b-tab v-for="page in pages" :title="page.title" :key="page.id">
+        <b-tab
+            v-for="page in pages"
+            :title="page.title"
+            :key="page.id"
+            :title-link-class="tabStyle(page.title)">
           <b-card-text>
             <component
               :is="page.component"
@@ -64,6 +73,8 @@ export default {
   name: "Annotation",
   data() {
     return {
+
+        tabNavTitle: "",
       // TODO: "pages" is used as static testing data. Should be replaced with actual list of used categories
       // from global state / store
       pages: [
@@ -75,11 +86,14 @@ export default {
     };
   },
   computed: {
+
     ...mapState([
-      "columnToCategoryMap",
-      "dataTable",
-      "dataDictionary",
-      "pageData"
+        "categories",
+        "categoryClasses",
+        "columnToCategoryMap",
+        "dataTable",
+        "dataDictionary",
+        "pageData"
     ]),
 
     nextPageButtonColor() {
@@ -88,7 +102,15 @@ export default {
         return this.pageData.download.accessible ? "success" : "secondary"
     }
   },
-  methods: {
+  methods: {      
+
+    tabStyle(p_category) {
+
+        console.log("tabStyle with category: " + p_category);
+        console.log("categoryClasses[" + p_category + "]: " + this.categoryClasses[p_category]);
+        return ["annotation-tab-nav", this.categoryClasses[p_category]];
+    },
+
     writeColumn(event) {
       // TODO: find a more succinct implementation. The "delete" operator should work, but somehow doesn't
       console.log(
@@ -124,6 +146,9 @@ export default {
 
         // 1. Set the current page name
         this.$store.dispatch("setCurrentPage", "annotation");
+
+        // 2. Set the initial tab title for styling purposes
+        this.tabNavTitle = this.categories[0];
     }
 
 };

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -24,7 +24,7 @@
 			<b-col cols="3">
 				<b-button
 					class="float-right"
-					:disabled="!isAnnotatedDataTableLoaded"
+					:disabled="!isDataAnnotated"
 					:variant="downloadButtonColor">
 					Download Annotated Data
 				</b-button>
@@ -68,18 +68,18 @@
 
             ...mapGetters([
 
-                "isAnnotatedDataTableLoaded"
+                "isDataAnnotated"
             ]),
 
 			downloadButtonColor() {
 
 				// Bootstrap variant color of the button leading to the output download
-				return this.isAnnotatedDataTableLoaded ? "success" : "secondary"
+				return this.isDataAnnotated ? "success" : "secondary"
 			},
 
             fields() {
 
-                if ( !this.isAnnotatedDataTableLoaded ) {
+                if ( !this.isDataAnnotated ) {
                     return [];
                 }
 
@@ -93,7 +93,7 @@
 			stringifiedDataTable() {
 
 				// 0. Return a blank string is there is no loaded data table
-				if ( !this.isAnnotatedDataTableLoaded ) {
+				if ( !this.isDataAnnotated ) {
 					return "";
 				}
 

--- a/pages/download.vue
+++ b/pages/download.vue
@@ -4,13 +4,17 @@
 
         <b-row >
 
-            <b-table
-                bordered
-                outlined
-                sticky-header
-                head-variant="dark"
-                :items="dataTable.annotated">
-            </b-table>
+            <b-col cols="12">
+                <b-table
+                    bordered
+                    outlined
+                    sticky-header
+                    striped
+                    head-variant="dark"
+                    :items="dataTable.annotated">
+                </b-table>
+            </b-col>
+            
             <!-- Debug component - shows file contents -->
             <!-- <textarea :rows="textArea.width" :cols="textArea.height" v-model="stringifiedDataTable"></textarea> -->
         </b-row>

--- a/store/index.js
+++ b/store/index.js
@@ -353,11 +353,6 @@ export const getters = {
 	categories(p_state) {
 
 		return p_state.categories;
-	},
-
-	isAnnotatedDataTableLoaded(p_state) {
-
-		return ( null != p_state.dataTable.annotated );
 	},	
 
 	isColumnLinkedToCategory: (p_state) => (p_matchData) => {
@@ -365,6 +360,27 @@ export const getters = {
 		// Check to see if the given column has been linked to the given category
 		return ( p_matchData.category === p_state.columnToCategoryMap[p_matchData.column] );
 	},
+
+	isDataAnnotated(p_state) {
+
+		// 1. Compare each row in the original and annotated tables
+		// NOTE: If any value is unequal, the data is considered 'annotated'
+		// We will likely want to revisit this qualification
+		for ( let originalRow of p_state.dataTable.original ) {
+			for ( let annotatedRow of p_state.dataTable.annotated ) {
+
+				// A. Check for unequal column values between the original and annotated tables
+				for ( let column in originalRow ) {
+					if ( annotatedRow[column] != originalRow[column] ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		// If all values in the tables are equal, data has not yet been annotated
+		return false;
+	},	
 
 	isDataDictionaryLoaded(p_state) {
 


### PR DESCRIPTION
This implements all of the changes as suggested in #93 - though there are still some places for whitespace improvements on the annotation page.

Also included is the stretching of the download page table to full size of the browser window.